### PR TITLE
build(deps): Use project module for app dependency

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -38,7 +38,7 @@ android {
 }
 
 dependencies {
-    implementation("io.github.surajkamble:cozy-tracker:0.1.0-SNAPSHOT")
+    implementation(project(":cozy_tracker"))
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(libs.androidx.activity.compose)


### PR DESCRIPTION
This commit updates the sample app's build configuration to depend directly on the `:cozy_tracker` project module instead of a published Maven artifact.

This change is typical during development, as it allows for faster iteration and testing of library changes without needing to publish to a local Maven repository first.

**Key changes:**
- **`app/build.gradle.kts`**: Replaces `implementation("io.github.surajkamble:cozy-tracker:0.1.0-SNAPSHOT")` with `implementation(project(":cozy_tracker"))`.