### PR TITLE
build(ci): Configure JitPack publishing and refactor build properties

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,4 +15,3 @@
 local.properties
 secring.gpg
 secret_key.asc
-gradle.properties

--- a/cozy_tracker/build.gradle.kts
+++ b/cozy_tracker/build.gradle.kts
@@ -9,6 +9,7 @@ android {
     compileSdk {
         version = release(36)
     }
+    ndkVersion = "26.1.10909125"
 
     defaultConfig {
         minSdk = 23

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,36 @@
+# Project-wide Gradle settings.
+# IDE (e.g. Android Studio) users:
+# Gradle settings configured through the IDE *will override*
+# any settings specified in this file.
+# For more details on how to configure your build environment visit
+# http://www.gradle.org/docs/current/userguide/build_environment.html
+# Specifies the JVM arguments used for the daemon process.
+# The setting is particularly useful for tweaking memory settings.
+# When configured, Gradle will run in incubating parallel mode.
+# This option should only be used with decoupled projects. For more details, visit
+# https://developer.android.com/r/tools/gradle-multi-project-decoupled-projects
+# org.gradle.parallel=true
+# AndroidX package structure to make it clearer which packages are bundled with the
+# Android operating system, and which are packaged with your app's APK
+# https://developer.android.com/topic/libraries/support-library/androidx-rn
+android.useAndroidX=true
+# Kotlin code style for this project: "official" or "obsolete":
+kotlin.code.style=official
+# Enables namespacing of each library's R class so that its R class includes only the
+# resources declared in the library itself and none from the library's dependencies,
+# thereby reducing the size of the R class for that library
+android.nonTransitiveRClass=true
+
+# Publishing coordinates (local + Maven Central later)
+GROUP=io.github.thesurajkamble
+POM_ARTIFACT_ID=cozy-tracker
+VERSION_NAME=1.0.2
+
+org.gradle.jvmargs=-Xmx4g -XX:MaxMetaspaceSize=512m -XX:+HeapDumpOnOutOfMemoryError
+
+# Enable parallel builds and caching for speed
+org.gradle.parallel=true
+org.gradle.caching=true
+
+# Optimization: Run R8/D8 in a separate process with more memory if needed
+android.enableR8.fullMode=true

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,2 +1,8 @@
 jdk:
   - openjdk17
+
+before_install:
+  - ./gradlew :cozy_tracker:assembleRelease
+
+install:
+  - ./gradlew :cozy_tracker:publishToMavenLocal


### PR DESCRIPTION
This commit introduces several changes to improve the project's build process and configure publishing via JitPack.

Key changes:
-   **`gradle.properties`**:
    -   A new `gradle.properties` file has been added to centralize project-wide configurations.
    -   It defines publishing coordinates like `GROUP`, `POM_ARTIFACT_ID`, and `VERSION_NAME`.
    -   Includes performance optimizations such as enabling parallel builds, caching, and configuring JVM arguments.
-   **`.gitignore`**:
    -   The `gradle.properties` file has been removed from `.gitignore`, allowing it to be tracked in version control.
-   **`jitpack.yml`**:
    -   Updated to run `assembleRelease` and `publishToMavenLocal` tasks before the install step, ensuring the library is built and published locally for JitPack to pick up.
-   **`cozy_tracker/build.gradle.kts`**:
    -   Specifies the `ndkVersion` to ensure a consistent build environment.