### PR TITLE
build: Bump version to 1.0.2

### DIFF
--- a/cozy_tracker/build.gradle.kts
+++ b/cozy_tracker/build.gradle.kts
@@ -61,7 +61,7 @@ dependencies {
 }
 
 group = (findProperty("GROUP") as String?) ?: "io.github.thesurajkamble"
-version = (findProperty("VERSION_NAME") as String?) ?: "0.1.0-SNAPSHOT"
+version = (findProperty("VERSION_NAME") as String?) ?: "1.0.2"
 
 afterEvaluate {
     publishing {
@@ -71,7 +71,7 @@ afterEvaluate {
 
                 groupId = "io.github.thesurajkamble"
                 artifactId = "cozy-tracker"
-                version = "0.1.0"
+                version = "1.0.2"
 
                 pom {
                     name.set("Cozy Tracker")


### PR DESCRIPTION
This commit updates the project's version from `0.1.0-SNAPSHOT` and `0.1.0` to `1.0.2` in the build configuration.

**Key changes:**
- **`cozy_tracker/build.gradle.kts`**:
    -   Updated the default `version` property.
    -   Updated the hardcoded `version` within the Maven publication POM block.