### PR TITLE
build(ci): Optimize JitPack build by removing Dokka tasks

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -5,4 +5,5 @@ before_install:
   - chmod +x gradlew
 
 install:
-  - ./gradlew :cozy_tracker:publishToMavenLocal -Dorg.gradle.jvmargs="-Xmx4g" -x test -x dokkaHtml -x dokkaJavadoc
+  - ./gradlew :cozy_tracker:publishToMavenLocal -Dorg.gradle.jvmargs="-Xmx4g" -x test
+    


### PR DESCRIPTION
This commit streamlines the JitPack build process by removing the `dokkaHtml` and `dokkaJavadoc` tasks from the `install` step.

This optimization speeds up the build by skipping the generation of documentation, which is not required for publishing the artifact.

**Key changes:**
- **`jitpack.yml`**:
    - Updated the `install` command to no longer exclude `-x dokkaHtml` and `-x dokkaJavadoc`.